### PR TITLE
Optimizations & bug fixes to the code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
       <dependency>
           <groupId>com.github.retrooper.packetevents</groupId>
           <artifactId>spigot</artifactId>
-          <version>2.2.1</version>
+          <version>2.3.0</version>
           <scope>provided</scope>
       </dependency>
   </dependencies>

--- a/src/main/java/me/kodysimpson/packetswithpacketevents/Packets_with_packet_events.java
+++ b/src/main/java/me/kodysimpson/packetswithpacketevents/Packets_with_packet_events.java
@@ -11,12 +11,16 @@ public final class Packets_with_packet_events extends JavaPlugin {
 
     //JavaDocs: https://packetevents.github.io/javadocs/
 
+    private static Packets_with_packet_events INSTANCE;
+
     @Override
     public void onLoad() {
+        INSTANCE = this;
         //we are using spigot
         PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
         //configure the settings
-        PacketEvents.getAPI().getSettings().reEncodeByDefault(false)
+        //reEncodeByDefault = allow modification of packets in your listeners by default.
+        PacketEvents.getAPI().getSettings().reEncodeByDefault(true)
                 .checkForUpdates(true)
                 .bStats(false);
         PacketEvents.getAPI().load();
@@ -35,5 +39,9 @@ public final class Packets_with_packet_events extends JavaPlugin {
     @Override
     public void onDisable() {
         PacketEvents.getAPI().terminate();
+    }
+
+    public static Packets_with_packet_events getInstance() {
+        return INSTANCE;
     }
 }

--- a/src/main/java/me/kodysimpson/packetswithpacketevents/listeners/VillageLookListener.java
+++ b/src/main/java/me/kodysimpson/packetswithpacketevents/listeners/VillageLookListener.java
@@ -2,6 +2,8 @@ package me.kodysimpson.packetswithpacketevents.listeners;
 
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityHeadLook;
+import me.kodysimpson.packetswithpacketevents.Packets_with_packet_events;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.EventHandler;
@@ -12,16 +14,20 @@ public class VillageLookListener implements Listener {
 
     @EventHandler
     public void onPlayerMovement(PlayerMoveEvent e) {
-
         //when the player moves within 5 blocks of a villager, make the villager look at the player
         e.getPlayer().getNearbyEntities(5, 5, 5).stream()
                 .filter(entity -> entity instanceof Villager)
                 .forEach(entity -> {
                     float yaw = calculateYawToFacePlayer(entity.getLocation(), e.getPlayer().getLocation());
-                    WrapperPlayServerEntityHeadLook packet = new WrapperPlayServerEntityHeadLook(entity.getEntityId(), yaw);
+                    //Generally a good practice to send packets asynchronously .
+                    //Hint: We are in a bukkit event, most events are not triggered async.
+                    Bukkit.getScheduler().runTaskAsynchronously(Packets_with_packet_events.getInstance(), () -> {
+                        WrapperPlayServerEntityHeadLook packet = new WrapperPlayServerEntityHeadLook(entity.getEntityId(), yaw);
 
-                    //send it to this player only so the villager looks at them specifically
-                    PacketEvents.getAPI().getPlayerManager().sendPacket(e.getPlayer(), packet);
+                        //send it to this player only so the villager looks at them specifically
+                        PacketEvents.getAPI().getPlayerManager().sendPacket(e.getPlayer(), packet);
+                    });
+
                 });
 
     }


### PR DESCRIPTION
* Updated to PacketEvents 2.3.0
* Optimized the packet-sending code (sending packets asynchronously is a good practice since it is a blocking operation)
* Optimized the animal attack detection code (We can utilize SpigotConversionUtil#getEntityById and can avoid switching threads)
* Enabled reEncodeByDefault, I'm not sure how the code previewed in the video *worked* having this disabled, since it's necessary to modify packets. You might have tweaked it after the video.